### PR TITLE
Add YouTube to MP3 backend service

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,20 @@ where you can submit a video URL and download the audio.
    ```bash
    npm install
    ```
-2. Start the development server:
+2. Start the backend server:
+   ```bash
+   npm run server
+   ```
+   This starts an Express service on `http://localhost:3001` that converts
+   YouTube videos to MP3 files.
+3. In a separate terminal start the development server:
    ```bash
    npm run dev
    ```
-3. Open `http://localhost:5173` in your browser.
+4. Open `http://localhost:5173` in your browser.
+
+The backend uses `ffmpeg` for audio conversion. Ensure `ffmpeg` is installed
+and available in your `PATH` before running the server.
 
 ## Building for Production
 
@@ -32,5 +41,6 @@ The build output will be in the `dist` directory.
 - `src/App.scss` – Styles for the app (SCSS)
 - `src/main.jsx` – Application entry point
 - `vite.config.js` – Vite configuration
+- `server/index.js` – Express backend providing the `/api/convert` endpoint
 
 Replace the placeholder images in `App.jsx` with your own content to personalize the page.

--- a/package.json
+++ b/package.json
@@ -5,11 +5,15 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "express": "^4.18.2",
+    "fluent-ffmpeg": "^2.1.2",
+    "ytdl-core": "^4.11.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.1.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const ytdl = require('ytdl-core');
+const ffmpeg = require('fluent-ffmpeg');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+app.get('/api/convert', async (req, res) => {
+  const videoUrl = req.query.url;
+  if (!videoUrl || !ytdl.validateURL(videoUrl)) {
+    return res.status(400).json({ error: 'Invalid URL' });
+  }
+
+  try {
+    const info = await ytdl.getInfo(videoUrl);
+    const title = info.videoDetails.title.replace(/[^a-z0-9]/gi, '_').toLowerCase();
+
+    res.setHeader('Content-Disposition', `attachment; filename="${title}.mp3"`);
+    res.setHeader('Content-Type', 'audio/mpeg');
+
+    const stream = ytdl(videoUrl, { quality: 'highestaudio' });
+    ffmpeg(stream)
+      .audioBitrate(128)
+      .format('mp3')
+      .on('error', (err) => {
+        console.error(err);
+        res.status(500).end();
+      })
+      .pipe(res, { end: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Conversion failed' });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/src/pages/Converter.jsx
+++ b/src/pages/Converter.jsx
@@ -9,8 +9,18 @@ export default function Converter() {
     if (!url) return;
     setStatus('Converting...');
     try {
-      // This would normally call a backend service to perform the conversion.
-      await new Promise((r) => setTimeout(r, 1000));
+      const response = await fetch(`/api/convert?url=${encodeURIComponent(url)}`);
+      if (!response.ok) throw new Error('Failed');
+      const blob = await response.blob();
+      const href = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.style.display = 'none';
+      a.href = href;
+      a.download = 'audio.mp3';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(href);
       setStatus('Conversion complete!');
     } catch (err) {
       setStatus('Conversion failed');

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,5 +2,10 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  plugins: [react()]
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3001'
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- create Express backend to convert YouTube URLs to mp3
- update converter page to call new API and download files
- configure Vite dev server proxy for API requests
- document backend setup in README
- add server dependencies and npm script

## Testing
- `npm test` *(fails: Missing script and network access blocked)*
- `npm run build` *(fails: vite not found due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_68591f004ab8832ea65992e4b9d47ba6