### PR TITLE
Add Dockerfile and instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:18-slim
+
+# Install ffmpeg for audio conversion
+RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
+
+# Create app directory
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm install
+
+# Copy source code
+COPY . .
+
+# Expose default ports for server and Vite dev server
+EXPOSE 3001 5173
+
+# Start the Express backend and Vite dev server
+CMD ["sh", "-c", "npm run server & npm run dev"]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,24 @@ where you can submit a video URL and download the audio.
 The backend uses `ffmpeg` for audio conversion. Ensure `ffmpeg` is installed
 and available in your `PATH` before running the server.
 
+## Running in Docker
+
+You can also use Docker to run the application with all dependencies preinstalled.
+
+1. Build the image (requires internet access to download npm packages and ffmpeg):
+   ```bash
+   docker build -t daily-toolkit .
+   ```
+2. Start the container:
+   ```bash
+   docker run --rm -p 5173:5173 -p 3001:3001 daily-toolkit
+   ```
+3. Open `http://localhost:5173` in your browser.
+
+The container installs `ffmpeg` and runs both the Express backend and Vite dev
+server. Your environment still needs outbound network access for the backend to
+fetch YouTube videos.
+
 ## Building for Production
 
 To create a production build:


### PR DESCRIPTION
## Summary
- add Dockerfile that installs ffmpeg and starts both the server and Vite dev server
- document how to build and run the new container in the README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685931b8e07c832e8ead1ae741ecf09e