### PR TITLE
Improve converter error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,14 @@ npm test
 ```
 
 This runs the Jest test suite which exercises the Express backend.
+
+## Troubleshooting
+
+If the backend responds with an error mentioning `Could not extract functions`,
+update the `ytdl-core` dependency to a newer version:
+
+```bash
+npm install ytdl-core@latest
+```
+
+You may need to rebuild the Docker image if you're running inside a container.

--- a/src/pages/Converter.jsx
+++ b/src/pages/Converter.jsx
@@ -10,7 +10,10 @@ export default function Converter() {
     setStatus('Converting...');
     try {
       const response = await fetch(`/api/convert?url=${encodeURIComponent(url)}`);
-      if (!response.ok) throw new Error('Failed');
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.error || 'Conversion failed');
+      }
       const blob = await response.blob();
       const href = window.URL.createObjectURL(blob);
       const a = document.createElement('a');
@@ -22,7 +25,7 @@ export default function Converter() {
       window.URL.revokeObjectURL(href);
       setStatus('Conversion complete!');
     } catch (err) {
-      setStatus('Conversion failed');
+      setStatus(err.message || 'Conversion failed');
     }
   };
 


### PR DESCRIPTION
## Summary
- expose server error messages in converter UI
- document how to resolve `Could not extract functions` failures

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593b4a9adc832ebdda421126608a8d