### PR TITLE
feat: add 3d path placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Simple Tower Defense Game
 
-This repository contains a minimal Godot project demonstrating a very basic tower defense game. Enemies follow a path while a single tower automatically attacks them.
+This repository contains a minimal **3D** Godot project demonstrating a very basic tower defense prototype. The player can place path segments to guide enemies toward the core while a single tower automatically attacks nearby enemies.
 
-Open `project.godot` in Godot and run the main scene to try it out.
+Open `project.godot` in Godot and run the main scene to try it out. Press the space bar to place additional path segments.

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,3 @@
+# Assets
+
+Placeholder 3D scenes used by the game. They contain simple box meshes so the project can be run without external resources.

--- a/assets/models/core.tscn
+++ b/assets/models/core.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=3 uid="uid://core"]
+
+[sub_resource type="BoxMesh" id="1"]
+size = Vector3(2, 2, 2)
+
+[node name="Core" type="Node3D"]
+
+[node name="Mesh" type="MeshInstance3D" parent="."]
+mesh = SubResource("1")

--- a/assets/models/enemy.tscn
+++ b/assets/models/enemy.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=3 format=3 uid="uid://enemy"]
+
+[ext_resource type="Script" path="res://enemy.gd" id="1"]
+
+[sub_resource type="BoxMesh" id="1"]
+size = Vector3(1, 1, 1)
+
+[node name="Enemy" type="Node3D"]
+script = ExtResource("1")
+
+[node name="Mesh" type="MeshInstance3D" parent="."]
+mesh = SubResource("1")

--- a/assets/models/path.tscn
+++ b/assets/models/path.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=3 uid="uid://pathseg"]
+
+[sub_resource type="BoxMesh" id="1"]
+size = Vector3(2, 0.25, 2)
+
+[node name="Path" type="Node3D"]
+
+[node name="Mesh" type="MeshInstance3D" parent="."]
+mesh = SubResource("1")

--- a/assets/models/tower.tscn
+++ b/assets/models/tower.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=3 format=3 uid="uid://tower"]
+
+[ext_resource type="Script" path="res://tower.gd" id="1"]
+
+[sub_resource type="BoxMesh" id="1"]
+size = Vector3(1, 1, 1)
+
+[node name="Tower" type="Node3D"]
+script = ExtResource("1")
+
+[node name="Mesh" type="MeshInstance3D" parent="."]
+mesh = SubResource("1")

--- a/enemy.gd
+++ b/enemy.gd
@@ -1,20 +1,30 @@
-extends Node2D
+extends Node3D
 
-@export var speed := 50
-var path: Array = []
-var _current_point := 0
+@export var speed := 5.0
+@export var detection_radius := 2.0
+var current_index := -1
 var hp := 3
 
-func _process(delta: float) -> void:
-    if _current_point >= path.size():
-        queue_free()
+func _physics_process(delta: float) -> void:
+    var main = get_tree().get_root().get_node("Main")
+    var positions: Array = main.path_positions
+    for i in range(positions.size()):
+        if position.distance_to(positions[i]) <= detection_radius:
+            current_index = i
+            break
+    if current_index == -1:
         return
-    var target: Vector2 = path[_current_point]
+    var next_index := current_index + 1
+    if next_index >= positions.size():
+        print("Game Over")
+        get_tree().quit()
+        return
+    var target: Vector3 = positions[next_index]
     var direction := (target - position).normalized()
     var distance := speed * delta
     if position.distance_to(target) <= distance:
         position = target
-        _current_point += 1
+        current_index = next_index
     else:
         position += direction * distance
 

--- a/main.gd
+++ b/main.gd
@@ -1,31 +1,56 @@
-extends Node2D
+extends Node3D
 
-var Enemy = preload("res://enemy.gd")
-var Tower = preload("res://tower.gd")
+var EnemyScene = preload("res://assets/models/enemy.tscn")
+var TowerScene = preload("res://assets/models/tower.tscn")
+var PathScene = preload("res://assets/models/path.tscn")
+var CoreScene = preload("res://assets/models/core.tscn")
 
-var path := [
-    Vector2(0, 0),
-    Vector2(400, 0),
-    Vector2(400, 400)
-]
-
+var path_positions: Array = []
 var spawn_time := 0.0
+var available_slots := [
+    Vector3(-15, 0, 0),
+    Vector3(-10, 0, 5),
+    Vector3(-5, 0, 5),
+    Vector3(-5, 0, 0)
+]
+var next_slot := 0
 
 func _ready() -> void:
-    var tower = Tower.new()
-    tower.position = Vector2(200, 200)
+    var core = CoreScene.instantiate()
+    core.position = Vector3(0, 0, 0)
+    add_child(core)
+    path_positions = [Vector3(-20, 0, 0), core.position]
+    var start_path = PathScene.instantiate()
+    start_path.position = path_positions[0]
+    start_path.add_to_group("paths")
+    add_child(start_path)
+    var tower = TowerScene.instantiate()
+    tower.position = Vector3(-10, 0, 2)
     add_child(tower)
     set_process(true)
+    set_process_input(true)
+
+func _input(event: InputEvent) -> void:
+    if event.is_action_pressed("place_path"):
+        if next_slot < available_slots.size():
+            add_path_segment(available_slots[next_slot])
+            next_slot += 1
+
+func add_path_segment(pos: Vector3) -> void:
+    path_positions.insert(path_positions.size() - 1, pos)
+    var p = PathScene.instantiate()
+    p.position = pos
+    p.add_to_group("paths")
+    add_child(p)
 
 func _process(delta: float) -> void:
     spawn_time -= delta
     if spawn_time <= 0:
         spawn_enemy()
-        spawn_time = 2
+        spawn_time = 2.0
 
 func spawn_enemy() -> void:
-    var enemy = Enemy.new()
-    enemy.position = path[0]
-    enemy.path = path
+    var enemy = EnemyScene.instantiate()
+    enemy.position = path_positions[0]
     add_child(enemy)
     enemy.add_to_group("enemies")

--- a/main.tscn
+++ b/main.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://d6guqblk1q8u" path="res://main.gd" id="1"]
 
-[node name="Main" type="Node2D"]
+[node name="Main" type="Node3D"]
 script = ExtResource("1")

--- a/project.godot
+++ b/project.godot
@@ -14,3 +14,6 @@ config/name="New Godot Game"
 run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.4")
 config/icon="res://icon.svg"
+
+[input]
+place_path={"deadzone":0.5,"events":[{"type":"key","keycode":32}]}

--- a/tower.gd
+++ b/tower.gd
@@ -1,10 +1,10 @@
-extends Node2D
+extends Node3D
 
-@export var range := 100
+@export var range := 10.0
 @export var fire_rate := 1.0
 var _cooldown := 0.0
 
-func _process(delta: float) -> void:
+func _physics_process(delta: float) -> void:
     _cooldown -= delta
     if _cooldown > 0:
         return


### PR DESCRIPTION
## Summary
- add 3D placeholder assets for enemy, tower, path segments and the core
- convert logic to 3D and let players place path segments that redirect enemies to the core
- document the new 3D gameplay and controls

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892f0e476f4832e9d7ee86644b65c8f