### PR TITLE
Add camera and light to main scene

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 This repository contains a minimal **3D** Godot project demonstrating a very basic tower defense prototype. The player can place path segments to guide enemies toward the core while a single tower automatically attacks nearby enemies.
 
 Open `project.godot` in Godot and run the main scene to try it out. Press the space bar to place additional path segments.
+
+The main scene now includes a basic camera and directional light so the level is visible without additional setup.

--- a/main.tscn
+++ b/main.tscn
@@ -4,3 +4,11 @@
 
 [node name="Main" type="Node3D"]
 script = ExtResource("1")
+
+[node name="Camera3D" type="Camera3D" parent="."]
+position = Vector3(0, 10, 20)
+rotation_degrees = Vector3(-30, 0, 0)
+current = true
+
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
+rotation_degrees = Vector3(-45, 0, 0)


### PR DESCRIPTION
## Summary
- Add Camera3D and DirectionalLight3D to the main scene for basic viewing and lighting
- Document the presence of default camera and light in README

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892f4287e94832e8dfcd66974847c15