### PR TITLE
Add wave control and path editing restrictions

### DIFF
--- a/main.gd
+++ b/main.gd
@@ -10,13 +10,16 @@ var CoreScene = preload("res://assets/models/core.tscn")
 var path_positions: Array = []
 var spawn_time := 0.0
 var spawn_interval := 2.0
-var game_started := false
+var game_loaded := false
+var waves_running := false
 var editing_mode := false
 
 @onready var start_menu = $CanvasLayer/Control
 @onready var start_button = $CanvasLayer/Control/VBoxContainer/StartButton
 @onready var hard_mode = $CanvasLayer/Control/VBoxContainer/HardMode
 @onready var edit_button = $CanvasLayer/EditButton
+@onready var run_button = $CanvasLayer/RunButton
+@onready var stop_button = $CanvasLayer/StopButton
 @onready var camera = $Camera3D
 var preview_path
 
@@ -48,38 +51,74 @@ func _ready() -> void:
 		preview_path.visible = false
 		add_child(preview_path)
 
-		start_button.pressed.connect(start_game)
-		edit_button.pressed.connect(toggle_edit)
-		edit_button.visible = false
-		set_process(true)
-		set_process_input(true)
-		set_physics_process(true)
+                start_button.pressed.connect(start_game)
+                edit_button.pressed.connect(toggle_edit)
+                run_button.pressed.connect(start_waves)
+                stop_button.pressed.connect(stop_waves)
+                edit_button.visible = false
+                run_button.visible = false
+                stop_button.visible = false
+                set_process(true)
+                set_process_input(true)
+                set_physics_process(true)
 
 func start_game() -> void:
-		game_started = true
-		start_menu.hide()
-		edit_button.show()
+                game_loaded = true
+                start_menu.hide()
+                edit_button.show()
+                run_button.show()
+                stop_button.hide()
+                editing_mode = true
+                edit_button.text = "Resume"
 
-		if hard_mode.button_pressed:
-				spawn_interval = 1.0
-		else:
-				spawn_interval = 2.0
-
-		spawn_time = spawn_interval
+                if hard_mode.button_pressed:
+                                spawn_interval = 1.0
+                else:
+                                spawn_interval = 2.0
 
 func toggle_edit() -> void:
-		editing_mode = not editing_mode
-		edit_button.text = "Resume" if editing_mode else "Edit Paths"
-		var enemies = get_tree().get_nodes_in_group("enemies")
-		for e in enemies:
-				e.set_physics_process(not editing_mode)
+                if waves_running:
+                                return
+                editing_mode = not editing_mode
+                edit_button.text = "Resume" if editing_mode else "Edit Paths"
+                preview_path.visible = editing_mode
+                var enemies = get_tree().get_nodes_in_group("enemies")
+                for e in enemies:
+                                e.set_physics_process(not editing_mode)
+
+func start_waves() -> void:
+                if not game_loaded:
+                                return
+                waves_running = true
+                editing_mode = false
+                edit_button.disabled = true
+                edit_button.text = "Edit Paths"
+                run_button.hide()
+                stop_button.show()
+                preview_path.hide()
+                spawn_time = spawn_interval
+
+func stop_waves() -> void:
+                if not waves_running:
+                                return
+                waves_running = false
+                editing_mode = true
+                edit_button.disabled = false
+                edit_button.text = "Resume"
+                run_button.show()
+                stop_button.hide()
+                preview_path.show()
+                spawn_time = spawn_interval
+                var enemies = get_tree().get_nodes_in_group("enemies")
+                for e in enemies:
+                                e.queue_free()
 
 func _input(event: InputEvent) -> void:
-		if not game_started:
-				return
+                if not game_loaded or not editing_mode:
+                                return
 
-		if event.is_action_pressed("place_path"):
-				add_path_segment(preview_path.position)
+                if event.is_action_pressed("place_path"):
+                                add_path_segment(preview_path.position)
 
 func add_path_segment(pos: Vector3) -> void:
 		pos.y = 0
@@ -90,8 +129,8 @@ func add_path_segment(pos: Vector3) -> void:
 		add_child(p)
 
 func _physics_process(delta: float) -> void:
-		if not game_started:
-				return
+                if not game_loaded:
+                                return
 
 		var input_dir := Vector3.ZERO
 		if Input.is_action_pressed("move_forward"):
@@ -107,16 +146,16 @@ func _physics_process(delta: float) -> void:
 				camera.translate(input_dir * camera_speed * delta)
 
 func _process(delta: float) -> void:
-		if game_started:
-				update_preview()
+                if editing_mode:
+                                update_preview()
 
-		if not game_started or editing_mode:
-				return
+                if not waves_running:
+                                return
 
-		spawn_time -= delta
-		if spawn_time <= 0:
-				spawn_enemy()
-				spawn_time = spawn_interval
+                spawn_time -= delta
+                if spawn_time <= 0:
+                                spawn_enemy()
+                                spawn_time = spawn_interval
 
 func update_preview() -> void:
 		var mouse_pos = get_viewport().get_mouse_position()

--- a/main.tscn
+++ b/main.tscn
@@ -44,3 +44,13 @@ text = "Hard Mode"
 [node name="EditButton" type="Button" parent="CanvasLayer"]
 visible = false
 text = "Edit Paths"
+
+[node name="RunButton" type="Button" parent="CanvasLayer"]
+visible = false
+offset_top = 40.0
+text = "Start Waves"
+
+[node name="StopButton" type="Button" parent="CanvasLayer"]
+visible = false
+offset_top = 80.0
+text = "Stop Waves"


### PR DESCRIPTION
## Summary
- Allow path editing only in a dedicated editing mode
- Add buttons to start and stop enemy waves separately
- Lock path editing while waves are active and reset enemies when waves stop

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689306a1dd30832ea1e6feb73f9f91a3