### PR TITLE
Add RTS camera and edit-mode placement options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This repository contains a minimal **3D** Godot project demonstrating a very basic tower defense prototype. The player can place path segments to guide enemies toward the core while a single tower automatically attacks nearby enemies.
 
-Open `project.godot` in Godot and run the main scene to try it out. Press the **Start Game** button to begin. Use **WASD** to move the camera and left click to place additional path segments where the mouse points at ground level. A transparent preview shows where the segment will appear. The settings menu also includes a simple **Hard Mode** toggle that increases the enemy spawn rate. Use the **Edit Paths** button at the top of the screen to pause the action and modify the path.
+Open `project.godot` in Godot and run the main scene to try it out. Press the **Start Game** button to begin. Use the RTS-style camera: **WASD**/**QE** to move, hold **right mouse** to rotate, **middle mouse** to pan or move near the screen edges to scroll, and use the scroll wheel to zoom. In edit mode, click **Place Path** or **Place Turret** to choose what to place. Left click to add segments or towers at the transparent preview. The settings menu also includes a simple **Hard Mode** toggle that increases the enemy spawn rate. Use the **Edit** button at the top of the screen to pause the action and modify the layout.
 
 The main scene includes a basic camera and directional light so the level is visible without additional setup.

--- a/main.gd
+++ b/main.gd
@@ -5,14 +5,13 @@ var TowerScene = preload("res://assets/models/tower.tscn")
 var PathScene = preload("res://assets/models/path.tscn")
 var CoreScene = preload("res://assets/models/core.tscn")
 
-@export var camera_speed := 5.0
-
 var path_positions: Array = []
 var spawn_time := 0.0
 var spawn_interval := 2.0
 var game_loaded := false
 var waves_running := false
 var editing_mode := false
+var placement_mode := "path"
 
 @onready var start_menu = $CanvasLayer/Control
 @onready var start_button = $CanvasLayer/Control/VBoxContainer/StartButton
@@ -20,8 +19,11 @@ var editing_mode := false
 @onready var edit_button = $CanvasLayer/EditButton
 @onready var run_button = $CanvasLayer/RunButton
 @onready var stop_button = $CanvasLayer/StopButton
+@onready var path_button = $CanvasLayer/PathButton
+@onready var turret_button = $CanvasLayer/TurretButton
 @onready var camera = $Camera3D
 var preview_path
+var preview_tower
 
 func _ready() -> void:
 		var core = CoreScene.instantiate()
@@ -39,37 +41,51 @@ func _ready() -> void:
 		tower.position = Vector3(-10, 0, 2)
 		add_child(tower)
 
-		preview_path = PathScene.instantiate()
-		var mesh = preview_path.get_node("Mesh") as MeshInstance3D
-		var material := StandardMaterial3D.new()
-		material.albedo_color = Color(1, 1, 1, 0.5)  # semi-transparent white
-		material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-		material.flags_transparent = true  # Enable transparency
+                preview_path = PathScene.instantiate()
+                var mesh = preview_path.get_node("Mesh") as MeshInstance3D
+                var material := StandardMaterial3D.new()
+                material.albedo_color = Color(1, 1, 1, 0.5)
+                material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+                material.flags_transparent = true
+                mesh.set_surface_override_material(0, material)
+                preview_path.visible = false
+                add_child(preview_path)
 
-		mesh.set_surface_override_material(0, material)
+                preview_tower = TowerScene.instantiate()
+                var tmesh = preview_tower.get_node("Mesh") as MeshInstance3D
+                var tmat := StandardMaterial3D.new()
+                tmat.albedo_color = Color(1, 1, 1, 0.5)
+                tmat.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+                tmat.flags_transparent = true
+                tmesh.set_surface_override_material(0, tmat)
+                preview_tower.visible = false
+                add_child(preview_tower)
 
-		preview_path.visible = false
-		add_child(preview_path)
-
-		start_button.pressed.connect(start_game)
-		edit_button.pressed.connect(toggle_edit)
-		run_button.pressed.connect(start_waves)
-		stop_button.pressed.connect(stop_waves)
-		edit_button.visible = false
-		run_button.visible = false
-		stop_button.visible = false
-		set_process(true)
-		set_process_input(true)
-		set_physics_process(true)
+                start_button.pressed.connect(start_game)
+                edit_button.pressed.connect(toggle_edit)
+                run_button.pressed.connect(start_waves)
+                stop_button.pressed.connect(stop_waves)
+                path_button.pressed.connect(set_mode_path)
+                turret_button.pressed.connect(set_mode_turret)
+                edit_button.visible = false
+                run_button.visible = false
+                stop_button.visible = false
+                path_button.visible = false
+                turret_button.visible = false
+                set_process(true)
+                set_process_input(true)
 
 func start_game() -> void:
-		game_loaded = true
-		start_menu.hide()
-		edit_button.show()
-		run_button.show()
-		stop_button.hide()
-		editing_mode = true
-		edit_button.text = "Resume"
+                game_loaded = true
+                start_menu.hide()
+                edit_button.show()
+                run_button.show()
+                stop_button.hide()
+                path_button.show()
+                turret_button.show()
+                editing_mode = true
+                edit_button.text = "Resume"
+                set_mode_path()
 
 		if hard_mode.button_pressed:
 				spawn_interval = 1.0
@@ -77,73 +93,81 @@ func start_game() -> void:
 				spawn_interval = 2.0
 
 func toggle_edit() -> void:
-		if waves_running:
-				return
-		editing_mode = not editing_mode
-		edit_button.text = "Resume" if editing_mode else "Edit Paths"
-		preview_path.visible = editing_mode
-		var enemies = get_tree().get_nodes_in_group("enemies")
-		for e in enemies:
-				e.set_physics_process(not editing_mode)
+                if waves_running:
+                                return
+                editing_mode = not editing_mode
+                edit_button.text = "Resume" if editing_mode else "Edit"
+                if editing_mode:
+                                if placement_mode == "path":
+                                                preview_path.show()
+                                else:
+                                                preview_tower.show()
+                else:
+                                preview_path.hide()
+                                preview_tower.hide()
+                path_button.disabled = not editing_mode
+                turret_button.disabled = not editing_mode
+                var enemies = get_tree().get_nodes_in_group("enemies")
+                for e in enemies:
+                                e.set_physics_process(not editing_mode)
 
 func start_waves() -> void:
-		if not game_loaded:
-				return
-		waves_running = true
-		editing_mode = false
-		edit_button.disabled = true
-		edit_button.text = "Edit Paths"
-		run_button.hide()
-		stop_button.show()
-		preview_path.hide()
-		spawn_time = spawn_interval
+                if not game_loaded:
+                                return
+                waves_running = true
+                editing_mode = false
+                edit_button.disabled = true
+                edit_button.text = "Edit"
+                run_button.hide()
+                stop_button.show()
+                preview_path.hide()
+                preview_tower.hide()
+                spawn_time = spawn_interval
 
 func stop_waves() -> void:
-		if not waves_running:
-				return
-		waves_running = false
-		editing_mode = true
-		edit_button.disabled = false
-		edit_button.text = "Resume"
-		run_button.show()
-		stop_button.hide()
-		preview_path.show()
-		spawn_time = spawn_interval
-		var enemies = get_tree().get_nodes_in_group("enemies")
-		for e in enemies:
-				e.queue_free()
+                if not waves_running:
+                                return
+                waves_running = false
+                editing_mode = true
+                edit_button.disabled = false
+                edit_button.text = "Resume"
+                run_button.show()
+                stop_button.hide()
+                if placement_mode == "path":
+                                preview_path.show()
+                                preview_tower.hide()
+                else:
+                                preview_tower.show()
+                                preview_path.hide()
+                spawn_time = spawn_interval
+                var enemies = get_tree().get_nodes_in_group("enemies")
+                for e in enemies:
+                                e.queue_free()
 
 func _input(event: InputEvent) -> void:
-		if not game_loaded or not editing_mode:
-				return
+                if not game_loaded or not editing_mode:
+                                return
 
-		if event.is_action_pressed("place_path"):
-				add_path_segment(preview_path.position)
+                if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+                                if placement_mode == "path":
+                                                add_path_segment(preview_path.position)
+                                else:
+                                                place_turret(preview_tower.position)
 
 func add_path_segment(pos: Vector3) -> void:
-		pos.y = 0
-		path_positions.insert(path_positions.size() - 1, pos)
-		var p = PathScene.instantiate()
-		p.position = pos
-		p.add_to_group("paths")
-		add_child(p)
+                pos.y = 0
+                path_positions.insert(path_positions.size() - 1, pos)
+                var p = PathScene.instantiate()
+                p.position = pos
+                p.add_to_group("paths")
+                add_child(p)
 
-func _physics_process(delta: float) -> void:
-		if not game_loaded:
-				return
+func place_turret(pos: Vector3) -> void:
+                pos.y = 0
+                var t = TowerScene.instantiate()
+                t.position = pos
+                add_child(t)
 
-		var input_dir := Vector3.ZERO
-		if Input.is_action_pressed("move_forward"):
-				input_dir.z -= 1
-		if Input.is_action_pressed("move_backward"):
-				input_dir.z += 1
-		if Input.is_action_pressed("move_left"):
-				input_dir.x -= 1
-		if Input.is_action_pressed("move_right"):
-				input_dir.x += 1
-		if input_dir != Vector3.ZERO:
-				input_dir = input_dir.normalized()
-				camera.translate(input_dir * camera_speed * delta)
 
 func _process(delta: float) -> void:
 		if editing_mode:
@@ -158,16 +182,36 @@ func _process(delta: float) -> void:
 				spawn_time = spawn_interval
 
 func update_preview() -> void:
-		var mouse_pos = get_viewport().get_mouse_position()
-		var origin = camera.project_ray_origin(mouse_pos)
-		var dir = camera.project_ray_normal(mouse_pos)
-		if dir.y == 0:
-				preview_path.hide()
-				return
-		var t = -origin.y / dir.y
-		var pos = origin + dir * t
-		preview_path.position = pos
-		preview_path.show()
+                var mouse_pos = get_viewport().get_mouse_position()
+                var origin = camera.project_ray_origin(mouse_pos)
+                var dir = camera.project_ray_normal(mouse_pos)
+                if dir.y == 0:
+                                preview_path.hide()
+                                preview_tower.hide()
+                                return
+                var t = -origin.y / dir.y
+                var pos = origin + dir * t
+                pos = pos.snapped(Vector3.ONE)
+                if placement_mode == "path":
+                                preview_path.position = pos
+                                preview_path.show()
+                                preview_tower.hide()
+                else:
+                                preview_tower.position = pos
+                                preview_tower.show()
+                                preview_path.hide()
+
+func set_mode_path() -> void:
+                placement_mode = "path"
+                preview_tower.hide()
+                if editing_mode:
+                                preview_path.show()
+
+func set_mode_turret() -> void:
+                placement_mode = "turret"
+                preview_path.hide()
+                if editing_mode:
+                                preview_tower.show()
 
 func spawn_enemy() -> void:
 		var enemy = EnemyScene.instantiate()

--- a/main.tscn
+++ b/main.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://scoie85tspm8"]
+[gd_scene load_steps=3 format=3 uid="uid://scoie85tspm8"]
 
 [ext_resource type="Script" uid="uid://d6guqblk1q8u" path="res://main.gd" id="1"]
+[ext_resource type="Script" path="res://rts_camera.gd" id="2"]
 
 [node name="Main" type="Node3D"]
 script = ExtResource("1")
@@ -8,6 +9,7 @@ script = ExtResource("1")
 [node name="Camera3D" type="Camera3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 0.866025, 0.5, 0, -0.5, 0.866025, 0, 10, 20)
 current = true
+script = ExtResource("2")
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
@@ -54,3 +56,13 @@ text = "Start Waves"
 visible = false
 offset_top = 80.0
 text = "Stop Waves"
+
+[node name="PathButton" type="Button" parent="CanvasLayer"]
+visible = false
+offset_left = 120.0
+text = "Place Path"
+
+[node name="TurretButton" type="Button" parent="CanvasLayer"]
+visible = false
+offset_left = 240.0
+text = "Place Turret"

--- a/project.godot
+++ b/project.godot
@@ -55,3 +55,24 @@ move_right={
 "type": "key"
 }]
 }
+move_up={
+"deadzone": 0.5,
+"events": [{
+"keycode": 69,
+"type": "key",
+}]
+}
+move_down={
+"deadzone": 0.5,
+"events": [{
+"keycode": 81,
+"type": "key",
+}]
+}
+ui_shift={
+"deadzone": 0.5,
+"events": [{
+"keycode": 4194305,
+"type": "key",
+}]
+}

--- a/rts_camera.gd
+++ b/rts_camera.gd
@@ -1,0 +1,68 @@
+extends Camera3D
+
+@export var move_speed := 15.0
+@export var fast_speed := 50.0
+@export var rotation_speed := 0.005
+@export var pan_speed := 0.02
+@export var zoom_speed := 2.0
+@export var edge_margin := 10
+@export var edge_speed := 15.0
+
+var yaw := 0.0
+var pitch := -0.3
+
+func _ready():
+    Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+    yaw = rotation.y
+    pitch = rotation.x
+
+func _process(delta):
+    var speed = move_speed
+    if Input.is_action_pressed("ui_shift"):
+        speed = fast_speed
+    var dir = Vector3.ZERO
+    if Input.is_action_pressed("move_forward"):
+        dir.z -= 1
+    if Input.is_action_pressed("move_backward"):
+        dir.z += 1
+    if Input.is_action_pressed("move_left"):
+        dir.x -= 1
+    if Input.is_action_pressed("move_right"):
+        dir.x += 1
+    if Input.is_action_pressed("move_up"):
+        dir.y += 1
+    if Input.is_action_pressed("move_down"):
+        dir.y -= 1
+    if dir != Vector3.ZERO:
+        translate(basis * dir.normalized() * speed * delta)
+
+    if Input.get_mouse_mode() == Input.MOUSE_MODE_VISIBLE:
+        var mouse_pos = get_viewport().get_mouse_position()
+        var size = get_viewport().get_visible_rect().size
+        if mouse_pos.x <= edge_margin:
+            translate(-basis.x * edge_speed * delta)
+        elif mouse_pos.x >= size.x - edge_margin:
+            translate(basis.x * edge_speed * delta)
+        if mouse_pos.y <= edge_margin:
+            translate(-basis.z * edge_speed * delta)
+        elif mouse_pos.y >= size.y - edge_margin:
+            translate(basis.z * edge_speed * delta)
+
+func _unhandled_input(event):
+    if event is InputEventMouseButton:
+        if event.button_index == MOUSE_BUTTON_RIGHT:
+            Input.set_mouse_mode(event.pressed ? Input.MOUSE_MODE_CAPTURED : Input.MOUSE_MODE_VISIBLE)
+        elif event.button_index == MOUSE_BUTTON_MIDDLE:
+            Input.set_mouse_mode(event.pressed ? Input.MOUSE_MODE_CAPTURED : Input.MOUSE_MODE_VISIBLE)
+        elif event.button_index == MOUSE_BUTTON_WHEEL_UP:
+            translate(-basis.z * zoom_speed)
+        elif event.button_index == MOUSE_BUTTON_WHEEL_DOWN:
+            translate(basis.z * zoom_speed)
+    elif event is InputEventMouseMotion:
+        if Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT):
+            yaw -= event.relative.x * rotation_speed
+            pitch = clamp(pitch - event.relative.y * rotation_speed, -1.2, 0.2)
+            rotation.y = yaw
+            rotation.x = pitch
+        elif Input.is_mouse_button_pressed(MOUSE_BUTTON_MIDDLE):
+            translate((-basis.x * event.relative.x - basis.z * event.relative.y) * pan_speed)


### PR DESCRIPTION
## Summary
- Add RTS-style camera controller with WASD/QE movement, edge scrolling, mouse rotation, panning, and zoom
- Introduce edit-mode buttons to choose between placing paths or turrets with previews
- Update input map and documentation for new controls

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68930b140694832eacc7fcf518d291a2