### PR TITLE
Improve input and pathfinding

### DIFF
--- a/enemy.gd
+++ b/enemy.gd
@@ -6,27 +6,40 @@ var current_index := -1
 var hp := 3
 
 func _physics_process(delta: float) -> void:
-	var main = get_tree().get_root().get_node("Main")
-	var positions: Array = main.path_positions
-	for i in range(positions.size()):
-		if position.distance_to(positions[i]) <= detection_radius:
-			current_index = i
-			break
-	if current_index == -1:
-		return
-	var next_index := current_index + 1
-	if next_index >= positions.size():
-		print("Game Over")
-		get_tree().quit()
-		return
-	var target: Vector3 = positions[next_index]
-	var direction := (target - position).normalized()
-	var distance := speed * delta
-	if position.distance_to(target) <= distance:
-		position = target
-		current_index = next_index
-	else:
-		position += direction * distance
+        var main = get_tree().get_root().get_node("Main")
+        var positions: Array = main.path_positions
+        var core_pos: Vector3 = positions[positions.size() - 1]
+
+        var found_path := false
+        for i in range(positions.size()):
+                if position.distance_to(positions[i]) <= detection_radius:
+                        current_index = i
+                        found_path = true
+                        break
+        if not found_path:
+                current_index = -1
+
+        var target: Vector3 = core_pos
+        if current_index != -1:
+                var next_index := current_index + 1
+                if next_index >= positions.size():
+                        print("Game Over")
+                        get_tree().quit()
+                        return
+                var next_target: Vector3 = positions[next_index]
+                if position.distance_to(core_pos) < position.distance_to(next_target):
+                        target = core_pos
+                else:
+                        target = next_target
+
+        var direction := (target - position).normalized()
+        var distance := speed * delta
+        if position.distance_to(target) <= distance:
+                position = target
+                if current_index != -1 and target != core_pos:
+                        current_index += 1
+        else:
+                position += direction * distance
 
 func take_damage(amount: int) -> void:
 	hp -= amount

--- a/main.gd
+++ b/main.gd
@@ -24,6 +24,8 @@ var placement_mode := "path"
 @onready var camera = $Camera3D
 var preview_path
 var preview_tower
+var selected_node: Node3D
+var original_material: Material
 
 func _ready() -> void:
 	var core = CoreScene.instantiate()
@@ -37,9 +39,10 @@ func _ready() -> void:
 	start_path.add_to_group("paths")
 	add_child(start_path)
 
-	var tower = TowerScene.instantiate()
-	tower.position = Vector3(-10, 0, 2)
-	add_child(tower)
+        var tower = TowerScene.instantiate()
+        tower.position = Vector3(-10, 0, 2)
+        add_child(tower)
+        tower.add_to_group("towers")
 
 	preview_path = PathScene.instantiate()
 	var mesh = preview_path.get_node("Mesh") as MeshInstance3D
@@ -71,8 +74,8 @@ func _ready() -> void:
 	stop_button.visible = false
 	path_button.visible = false
 	turret_button.visible = false
-	set_process(true)
-	set_process_input(true)
+        set_process(true)
+        set_process_unhandled_input(true)
 
 func start_game() -> void:
 	game_loaded = true
@@ -144,28 +147,83 @@ func stop_waves() -> void:
 		e.queue_free()
 
 func _input(event: InputEvent) -> void:
-	if not game_loaded or not editing_mode:
-		return
+func _unhandled_input(event: InputEvent) -> void:
+        if not game_loaded or not editing_mode:
+                return
 
-	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-		if placement_mode == "path":
-			add_path_segment(preview_path.position)
-		else:
-			place_turret(preview_tower.position)
+        if event is InputEventKey and event.pressed and event.keycode == KEY_DELETE and selected_node:
+                if selected_node.is_in_group("paths"):
+                        path_positions.erase(selected_node.position)
+                selected_node.queue_free()
+                selected_node = null
+                original_material = null
+                return
+
+        if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+                var mouse_pos = event.position
+                var origin = camera.project_ray_origin(mouse_pos)
+                var dir = camera.project_ray_normal(mouse_pos)
+                var space = get_world_3d().direct_space_state
+                var query = PhysicsRayQueryParameters3D.create(origin, origin + dir * 1000)
+                var result = space.intersect_ray(query)
+                if result:
+                        var node = result.collider
+                        if node.is_in_group("paths") or node.is_in_group("towers"):
+                                select_node(node)
+                                return
+                        elif node.get_parent() and (node.get_parent().is_in_group("paths") or node.get_parent().is_in_group("towers")):
+                                select_node(node.get_parent())
+                                return
+                clear_selection()
+                if placement_mode == "path":
+                        add_path_segment(preview_path.position)
+                else:
+                        place_turret(preview_tower.position)
 
 func add_path_segment(pos: Vector3) -> void:
-	pos.y = 0
-	path_positions.insert(path_positions.size() - 1, pos)
-	var p = PathScene.instantiate()
-	p.position = pos
-	p.add_to_group("paths")
-	add_child(p)
+        pos.y = 0
+        for n in get_tree().get_nodes_in_group("paths"):
+                if n.position == pos:
+                        return
+        for t in get_tree().get_nodes_in_group("towers"):
+                if t.position == pos:
+                        return
+        path_positions.insert(path_positions.size() - 1, pos)
+        var p = PathScene.instantiate()
+        p.position = pos
+        p.add_to_group("paths")
+        add_child(p)
 
 func place_turret(pos: Vector3) -> void:
-	pos.y = 0
-	var t = TowerScene.instantiate()
-	t.position = pos
-	add_child(t)
+        pos.y = 0
+        for n in get_tree().get_nodes_in_group("paths"):
+                if n.position == pos:
+                        return
+        for tt in get_tree().get_nodes_in_group("towers"):
+                if tt.position == pos:
+                        return
+        var t = TowerScene.instantiate()
+        t.position = pos
+        t.add_to_group("towers")
+        add_child(t)
+
+func select_node(node: Node3D) -> void:
+        clear_selection()
+        selected_node = node
+        var mesh = node.get_node_or_null("Mesh") as MeshInstance3D
+        if mesh:
+                original_material = mesh.get_active_material(0)
+                var mat := StandardMaterial3D.new()
+                mat.albedo_color = Color(1, 0, 0)
+                mesh.set_surface_override_material(0, mat)
+
+func clear_selection() -> void:
+        if selected_node:
+                var mesh = selected_node.get_node_or_null("Mesh") as MeshInstance3D
+                if mesh and original_material:
+                        mesh.set_surface_override_material(0, original_material)
+        selected_node = null
+        original_material = null
 
 
 func _process(delta: float) -> void:

--- a/project.godot
+++ b/project.godot
@@ -32,12 +32,18 @@ move_forward={
 "events": [{
 "keycode": 87,
 "type": "key"
+}, {
+"keycode": 4194320,
+"type": "key"
 }]
 }
 move_backward={
 "deadzone": 0.5,
 "events": [{
 "keycode": 83,
+"type": "key"
+}, {
+"keycode": 4194322,
 "type": "key"
 }]
 }
@@ -46,12 +52,18 @@ move_left={
 "events": [{
 "keycode": 65,
 "type": "key"
+}, {
+"keycode": 4194319,
+"type": "key"
 }]
 }
 move_right={
 "deadzone": 0.5,
 "events": [{
 "keycode": 68,
+"type": "key"
+}, {
+"keycode": 4194321,
 "type": "key"
 }]
 }

--- a/rts_camera.gd
+++ b/rts_camera.gd
@@ -10,6 +10,7 @@ extends Camera3D
 
 var yaw := 0.0
 var pitch := -0.3
+var middle_panning := false
 
 func _ready():
 	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
@@ -38,24 +39,24 @@ func _process(delta):
 
 ## Edge Movement
 
-	# if Input.get_mouse_mode() == Input.MOUSE_MODE_VISIBLE:
-	# 	var mouse_pos = get_viewport().get_mouse_position()
-	# 	var size = get_viewport().get_visible_rect().size
-	# 	if mouse_pos.x <= edge_margin:
-	# 		translate(-basis.x * edge_speed * delta)
-	# 	elif mouse_pos.x >= size.x - edge_margin:
-	# 		translate(basis.x * edge_speed * delta)
-	# 	if mouse_pos.y <= edge_margin:
-	# 		translate(-basis.z * edge_speed * delta)
-	# 	elif mouse_pos.y >= size.y - edge_margin:
-	# 		translate(basis.z * edge_speed * delta)
+	if Input.get_mouse_mode() == Input.MOUSE_MODE_VISIBLE:
+		var mouse_pos = get_viewport().get_mouse_position()
+		var size = get_viewport().get_visible_rect().size
+		if mouse_pos.x <= edge_margin:
+			translate(-basis.x * edge_speed * delta)
+		elif mouse_pos.x >= size.x - edge_margin:
+			translate(basis.x * edge_speed * delta)
+		if mouse_pos.y <= edge_margin:
+			translate(-basis.z * edge_speed * delta)
+		elif mouse_pos.y >= size.y - edge_margin:
+			translate(basis.z * edge_speed * delta)
 
 func _unhandled_input(event):
 	if event is InputEventMouseButton:
 		if event.button_index == MOUSE_BUTTON_RIGHT:
 			Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED if event.pressed else Input.MOUSE_MODE_VISIBLE)
 		elif event.button_index == MOUSE_BUTTON_MIDDLE:
-			Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED if event.pressed else Input.MOUSE_MODE_VISIBLE)
+			middle_panning = event.pressed
 		elif event.button_index == MOUSE_BUTTON_WHEEL_UP:
 			translate(-basis.z * zoom_speed)
 		elif event.button_index == MOUSE_BUTTON_WHEEL_DOWN:
@@ -66,5 +67,5 @@ func _unhandled_input(event):
 			pitch = clamp(pitch - event.relative.y * rotation_speed, -1.2, 0.2)
 			rotation.y = yaw
 			rotation.x = pitch
-		elif Input.is_mouse_button_pressed(MOUSE_BUTTON_MIDDLE):
+		elif middle_panning:
 			translate((basis.x * event.relative.x + basis.z * event.relative.y) * pan_speed)


### PR DESCRIPTION
## Summary
- Add proximity-aware enemy pathfinding that heads straight for the core when off-path
- Enable arrow-key camera controls, visible-edge scrolling and smoother middle-mouse panning
- Support selecting and deleting paths/turrets, while preventing overlapping placements

## Testing
- `godot --headless --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689312980e60832e94851e604fea28ce