### PR TITLE
Constrain camera and placement

### DIFF
--- a/assets/models/core.tscn
+++ b/assets/models/core.tscn
@@ -1,9 +1,22 @@
-[gd_scene load_steps=2 format=3 uid="uid://core"]
+[gd_scene load_steps=4 format=3 uid="uid://core"]
 
 [sub_resource type="BoxMesh" id="1"]
+size = Vector3(2, 2, 2)
+
+[sub_resource type="StandardMaterial3D" id="2"]
+albedo_color = Color(0, 1, 0)
+
+[sub_resource type="BoxShape3D" id="3"]
 size = Vector3(2, 2, 2)
 
 [node name="Core" type="Node3D"]
 
 [node name="Mesh" type="MeshInstance3D" parent="."]
 mesh = SubResource("1")
+material_override = SubResource("2")
+
+[node name="StaticBody3D" type="StaticBody3D" parent="."]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3D"]
+shape = SubResource("3")
+

--- a/assets/models/enemy.tscn
+++ b/assets/models/enemy.tscn
@@ -1,8 +1,11 @@
-[gd_scene load_steps=3 format=3 uid="uid://enemy"]
+[gd_scene load_steps=4 format=3 uid="uid://enemy"]
 
 [ext_resource type="Script" uid="uid://bexxmsg84lkd0" path="res://enemy.gd" id="1"]
 
 [sub_resource type="BoxMesh" id="1"]
+
+[sub_resource type="StandardMaterial3D" id="2"]
+albedo_color = Color(1, 0, 0)
 
 [node name="Enemy" type="Node3D"]
 script = ExtResource("1")
@@ -10,3 +13,5 @@ script = ExtResource("1")
 [node name="Mesh" type="MeshInstance3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.740464, 0)
 mesh = SubResource("1")
+material_override = SubResource("2")
+

--- a/assets/models/path.tscn
+++ b/assets/models/path.tscn
@@ -1,9 +1,22 @@
-[gd_scene load_steps=2 format=3 uid="uid://pathseg"]
+[gd_scene load_steps=4 format=3 uid="uid://pathseg"]
 
 [sub_resource type="BoxMesh" id="1"]
+size = Vector3(2, 0.25, 2)
+
+[sub_resource type="StandardMaterial3D" id="2"]
+albedo_color = Color(0, 0, 0)
+
+[sub_resource type="BoxShape3D" id="3"]
 size = Vector3(2, 0.25, 2)
 
 [node name="Path" type="Node3D"]
 
 [node name="Mesh" type="MeshInstance3D" parent="."]
 mesh = SubResource("1")
+material_override = SubResource("2")
+
+[node name="StaticBody3D" type="StaticBody3D" parent="."]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3D"]
+shape = SubResource("3")
+

--- a/assets/models/tower.tscn
+++ b/assets/models/tower.tscn
@@ -1,8 +1,14 @@
-[gd_scene load_steps=3 format=3 uid="uid://tower"]
+[gd_scene load_steps=5 format=3 uid="uid://tower"]
 
 [ext_resource type="Script" path="res://tower.gd" id="1"]
 
 [sub_resource type="BoxMesh" id="1"]
+size = Vector3(1, 1, 1)
+
+[sub_resource type="StandardMaterial3D" id="2"]
+albedo_color = Color(0, 0, 1)
+
+[sub_resource type="BoxShape3D" id="3"]
 size = Vector3(1, 1, 1)
 
 [node name="Tower" type="Node3D"]
@@ -10,3 +16,10 @@ script = ExtResource("1")
 
 [node name="Mesh" type="MeshInstance3D" parent="."]
 mesh = SubResource("1")
+material_override = SubResource("2")
+
+[node name="StaticBody3D" type="StaticBody3D" parent="."]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3D"]
+shape = SubResource("3")
+

--- a/main.gd
+++ b/main.gd
@@ -12,6 +12,8 @@ var game_loaded := false
 var waves_running := false
 var editing_mode := false
 var placement_mode := "path"
+const BOUNDS_MIN := Vector2(-25, -25)
+const BOUNDS_MAX := Vector2(25, 25)
 
 @onready var start_menu = $CanvasLayer/Control
 @onready var start_button = $CanvasLayer/Control/VBoxContainer/StartButton
@@ -38,6 +40,10 @@ func _ready() -> void:
 	start_path.position = path_positions[0]
 	start_path.add_to_group("paths")
 	add_child(start_path)
+	var sp_mesh = start_path.get_node("Mesh") as MeshInstance3D
+	var sp_mat := StandardMaterial3D.new()
+	sp_mat.albedo_color = Color(1, 0, 0)
+	sp_mesh.set_surface_override_material(0, sp_mat)
 
 	var tower = TowerScene.instantiate()
 	tower.position = Vector3(-10, 0, 2)
@@ -85,9 +91,12 @@ func start_game() -> void:
 	stop_button.hide()
 	path_button.show()
 	turret_button.show()
-	editing_mode = true
-	edit_button.text = "Resume"
-	set_mode_path()
+	editing_mode = false
+	edit_button.text = "Edit"
+	preview_path.hide()
+	preview_tower.hide()
+	path_button.disabled = true
+	turret_button.disabled = true
 
 	if hard_mode.button_pressed:
 		spawn_interval = 1.0
@@ -147,7 +156,7 @@ func stop_waves() -> void:
 		e.queue_free()
 
 func _unhandled_input(event: InputEvent) -> void:
-	if not game_loaded or not editing_mode:
+	if not game_loaded:
 		return
 
 	if event is InputEventKey and event.pressed and event.keycode == KEY_DELETE and selected_node:
@@ -174,19 +183,24 @@ func _unhandled_input(event: InputEvent) -> void:
 				select_node(node.get_parent())
 				return
 		clear_selection()
-		if placement_mode == "path":
-			add_path_segment(preview_path.position)
-		else:
-			place_turret(preview_tower.position)
+		if editing_mode:
+			if placement_mode == "path":
+				add_path_segment(preview_path.position)
+			else:
+				place_turret(preview_tower.position)
 
 func add_path_segment(pos: Vector3) -> void:
 	pos.y = 0
-	for n in get_tree().get_nodes_in_group("paths"):
-		if n.position == pos:
-			return
-	for t in get_tree().get_nodes_in_group("towers"):
-		if t.position == pos:
-			return
+	if not _within_bounds(pos):
+		return
+	var shape := BoxShape3D.new()
+	shape.size = Vector3(2, 0.25, 2)
+	var params := PhysicsShapeQueryParameters3D.new()
+	params.shape = shape
+	params.transform = Transform3D(Basis(), pos)
+	var space = get_world_3d().direct_space_state
+	if space.intersect_shape(params).size() > 0:
+		return
 	path_positions.insert(path_positions.size() - 1, pos)
 	var p = PathScene.instantiate()
 	p.position = pos
@@ -195,12 +209,16 @@ func add_path_segment(pos: Vector3) -> void:
 
 func place_turret(pos: Vector3) -> void:
 	pos.y = 0
-	for n in get_tree().get_nodes_in_group("paths"):
-		if n.position == pos:
-			return
-	for tt in get_tree().get_nodes_in_group("towers"):
-		if tt.position == pos:
-			return
+	if not _within_bounds(pos):
+		return
+	var shape := BoxShape3D.new()
+	shape.size = Vector3(1, 1, 1)
+	var params := PhysicsShapeQueryParameters3D.new()
+	params.shape = shape
+	params.transform = Transform3D(Basis(), pos)
+	var space = get_world_3d().direct_space_state
+	if space.intersect_shape(params).size() > 0:
+		return
 	var t = TowerScene.instantiate()
 	t.position = pos
 	t.add_to_group("towers")
@@ -223,7 +241,6 @@ func clear_selection() -> void:
 			mesh.set_surface_override_material(0, original_material)
 	selected_node = null
 	original_material = null
-
 
 func _process(delta: float) -> void:
 	if editing_mode:
@@ -250,11 +267,29 @@ func update_preview() -> void:
 	pos = pos.snapped(Vector3.ONE)
 	if placement_mode == "path":
 		preview_path.position = pos
-		preview_path.show()
+		var shape := BoxShape3D.new()
+		shape.size = Vector3(2, 0.25, 2)
+		var params := PhysicsShapeQueryParameters3D.new()
+		params.shape = shape
+		params.transform = Transform3D(Basis(), pos)
+		var space = get_world_3d().direct_space_state
+		if _within_bounds(pos) and space.intersect_shape(params).size() == 0:
+			preview_path.show()
+		else:
+			preview_path.hide()
 		preview_tower.hide()
 	else:
 		preview_tower.position = pos
-		preview_tower.show()
+		var shape_t := BoxShape3D.new()
+		shape_t.size = Vector3(1, 1, 1)
+		var params_t := PhysicsShapeQueryParameters3D.new()
+		params_t.shape = shape_t
+		params_t.transform = Transform3D(Basis(), pos)
+		var space_t = get_world_3d().direct_space_state
+		if _within_bounds(pos) and space_t.intersect_shape(params_t).size() == 0:
+			preview_tower.show()
+		else:
+			preview_tower.hide()
 		preview_path.hide()
 
 func set_mode_path() -> void:
@@ -274,3 +309,6 @@ func spawn_enemy() -> void:
 	enemy.position = path_positions[0]
 	add_child(enemy)
 	enemy.add_to_group("enemies")
+
+func _within_bounds(pos: Vector3) -> bool:
+	return pos.x >= BOUNDS_MIN.x and pos.x <= BOUNDS_MAX.x and pos.z >= BOUNDS_MIN.y and pos.z <= BOUNDS_MAX.y

--- a/rts_camera.gd
+++ b/rts_camera.gd
@@ -7,15 +7,19 @@ extends Camera3D
 @export var zoom_speed := 2.0
 @export var edge_margin := 10
 @export var edge_speed := 15.0
+@export var bounds_min := Vector2(-25, -25)
+@export var bounds_max := Vector2(25, 25)
 
 var yaw := 0.0
 var pitch := -0.3
-var middle_panning := false
+var fixed_height := 0.0
+var right_panning := false
+var rotating := false
 
 func _ready():
-	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
 	yaw = rotation.y
 	pitch = rotation.x
+	fixed_height = global_position.y
 
 func _process(delta):
 	var speed = move_speed
@@ -30,42 +34,54 @@ func _process(delta):
 		dir.x -= 1
 	if Input.is_action_pressed("move_right"):
 		dir.x += 1
-	if Input.is_action_pressed("move_up"):
-		dir.y += 1
-	if Input.is_action_pressed("move_down"):
-		dir.y -= 1
 	if dir != Vector3.ZERO:
-		translate(basis * dir.normalized() * speed * delta)
+		var forward = Vector3(0, 0, -1).rotated(Vector3.UP, yaw)
+		var right = Vector3(1, 0, 0).rotated(Vector3.UP, yaw)
+		var move_vec = (right * dir.x + forward * dir.z).normalized()
+		translate(move_vec * speed * delta)
+		_clamp_position()
 
-## Edge Movement
+	## Edge Movement
 
-	if Input.get_mouse_mode() == Input.MOUSE_MODE_VISIBLE:
-		var mouse_pos = get_viewport().get_mouse_position()
-		var size = get_viewport().get_visible_rect().size
-		if mouse_pos.x <= edge_margin:
-			translate(-basis.x * edge_speed * delta)
-		elif mouse_pos.x >= size.x - edge_margin:
-			translate(basis.x * edge_speed * delta)
-		if mouse_pos.y <= edge_margin:
-			translate(-basis.z * edge_speed * delta)
-		elif mouse_pos.y >= size.y - edge_margin:
-			translate(basis.z * edge_speed * delta)
+	var mouse_pos = get_viewport().get_mouse_position()
+	var size = get_viewport().get_visible_rect().size
+	var forward = Vector3(0, 0, -1).rotated(Vector3.UP, yaw)
+	var right = Vector3(1, 0, 0).rotated(Vector3.UP, yaw)
+	if mouse_pos.x <= edge_margin:
+		translate(-right * edge_speed * delta)
+	elif mouse_pos.x >= size.x - edge_margin:
+		translate(right * edge_speed * delta)
+	if mouse_pos.y <= edge_margin:
+		translate(forward * edge_speed * delta)
+	elif mouse_pos.y >= size.y - edge_margin:
+		translate(-forward * edge_speed * delta)
+	_clamp_position()
 
 func _unhandled_input(event):
 	if event is InputEventMouseButton:
 		if event.button_index == MOUSE_BUTTON_RIGHT:
-			Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED if event.pressed else Input.MOUSE_MODE_VISIBLE)
+			right_panning = event.pressed
 		elif event.button_index == MOUSE_BUTTON_MIDDLE:
-			middle_panning = event.pressed
+			rotating = event.pressed
 		elif event.button_index == MOUSE_BUTTON_WHEEL_UP:
-			translate(-basis.z * zoom_speed)
+			var forward = Vector3(0, 0, -1).rotated(Vector3.UP, yaw)
+			translate(forward * zoom_speed)
+			_clamp_position()
 		elif event.button_index == MOUSE_BUTTON_WHEEL_DOWN:
-			translate(basis.z * zoom_speed)
+			var forward = Vector3(0, 0, -1).rotated(Vector3.UP, yaw)
+			translate(-forward * zoom_speed)
+			_clamp_position()
 	elif event is InputEventMouseMotion:
-		if Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT):
+		if right_panning:
+			var right = Vector3(1, 0, 0).rotated(Vector3.UP, yaw)
+			var forward = Vector3(0, 0, -1).rotated(Vector3.UP, yaw)
+			translate((-right * event.relative.x + forward * event.relative.y) * pan_speed)
+			_clamp_position()
+		elif rotating:
 			yaw -= event.relative.x * rotation_speed
-			pitch = clamp(pitch - event.relative.y * rotation_speed, -1.2, 0.2)
 			rotation.y = yaw
-			rotation.x = pitch
-		elif middle_panning:
-			translate((basis.x * event.relative.x + basis.z * event.relative.y) * pan_speed)
+
+func _clamp_position() -> void:
+	global_position.y = fixed_height
+	global_position.x = clamp(global_position.x, bounds_min.x, bounds_max.x)
+	global_position.z = clamp(global_position.z, bounds_min.y, bounds_max.y)


### PR DESCRIPTION
## Summary
- Lock RTS camera to fixed altitude with horizontal rotation and edge panning while respecting scene bounds
- Start game in movement mode; restrict placement to editing mode with collision and boundary checks
- Apply consistent colors and collision shapes to core, paths, towers, enemies; enforce scene bounds for placements

## Testing
- `godot --headless --quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689316907a1c832e839396ca98d10c16